### PR TITLE
Makefile: Force `cp` to overwrite the existing one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ gconv-modules:
 .PHONY: gconvpath
 gconvpath:
 	mkdir -p GCONV_PATH=.
-	cp $(TRUE) GCONV_PATH=./pwnkit.so:.
+	cp -f $(TRUE) GCONV_PATH=./pwnkit.so:.
 
 pwnkit.so: pwnkit.c
 	$(CC) $(CFLAGS) --shared -fPIC -o $@ $<


### PR DESCRIPTION
```md
This fixes when the permissions of `true` on some Linux systems doesn't
have write privileges, while the permissions are fully preserved by cp.
```

On my Gentoo system, coreutils uses multicall, where the content of `/bin/true` is just a shebang with arguments and no write permissions. This only applies if wants to `make` again without cleaning it first (one-liner).
```sh
$ file /bin/true
/bin/true: a /usr/bin/coreutils --coreutils-prog-shebang=true script, ASCII text executable
$ getfacl /bin/true
getfacl: Removing leading '/' from absolute path names
# file: bin/true
# owner: root
# group: root
user::r-x
group::r-x
other::r-x
```